### PR TITLE
勉強会の外部参加窓口を右手・坂元に変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/----------.md
+++ b/.github/ISSUE_TEMPLATE/----------.md
@@ -11,7 +11,7 @@ assignees: ''
 
 推薦・機械学習勉強会は、推薦や機械学習、その周辺技術を通じてサービスを改善することにモチベーションのある人達の集まりです。ニュースやブログから論文まで、気になったものについてお互い共有しましょう！
 
-発信のため、ここは **public** にしてあります。外部からの参加をご希望の方は[林/python_walker](https://x.com/python_walker)、[市村/chimuichimu](https://x.com/chimuichimu1) まで DM を送るか、Wantedly Visit の募集（https://www.wantedly.com/projects/391912） よりご連絡ください！
+発信のため、ここは **public** にしてあります。外部からの参加をご希望の方は[右手/ghibney](https://x.com/ghibney)、[坂元/___nsak](https://x.com/___nsak) まで DM を送るか、Wantedly Visit の募集（https://www.wantedly.com/projects/391912） よりご連絡ください！
 
 ## What
 


### PR DESCRIPTION
## Why

推薦・機械学習勉強会の issue テンプレートに載っている外部参加者向けの DM 窓口を修正するため

## What

- `.github/ISSUE_TEMPLATE/----------.md` の連絡先を [林/python_walker](https://x.com/python_walker)、[市村/chimuichimu](https://x.com/chimuichimu1) から [右手/ghibney](https://x.com/ghibney)、[坂元/___nsak](https://x.com/___nsak) に変更